### PR TITLE
Fix header-only edge cases, improve generator/preset consistency

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     tags:
-      - "*"
+      - "v*"
 
 env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
@@ -11,27 +11,36 @@ env:
 jobs:
   build:
     name: Build and publish documentation
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
+    runs-on: ubuntu-24.04
 
-      - uses: actions/cache@v3
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
 
-      - name: Install dependencies
+      - name: Install GCC 14 and Doxygen
         run: |
-          brew install doxygen
-          pip3 install jinja2 Pygments
+          sudo apt-get update
+          sudo apt-get install -y gcc-14 g++-14 doxygen graphviz
 
-      - name: Build
+      - name: Configure
         run: |
-          cmake -Sdocumentation -Bbuild
-          cmake --build build --target GenerateDocs
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc-14 \
+            -DCMAKE_CXX_COMPILER=g++-14 \
+            -DMODERN_CPP_PROJECT_ENABLE_DOXYGEN=ON \
+            -DMODERN_CPP_PROJECT_ENABLE_TESTING=OFF \
+            -DMODERN_CPP_PROJECT_ENABLE_STANDALONE=OFF
 
-      - name: Publish
+      - name: Build documentation
+        run: cmake --build build --target doxygen-docs
+
+      - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build/doxygen/html
+          publish_dir: ./build/docs/html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,10 @@ if(PROJECT_IS_TOP_LEVEL)
     if(NOT CMAKE_BUILD_TYPE)
         set(CMAKE_BUILD_TYPE "Debug")
     endif()
+
+    if(${PROJECT_NAME_UPPERCASE}_ENABLE_DOXYGEN OR ENABLE_DOXYGEN)
+        include(cmake/Doxygen.cmake)
+    endif()
 endif()
 
 ##############################################################################
@@ -129,14 +133,6 @@ source_group(
 ##############################################################################
 # ---- Create library ----
 ##############################################################################
-if(${PROJECT_NAME_UPPERCASE}_BUILD_HEADERS_ONLY)
-    add_library(${PROJECT_NAME_LOWERCASE} INTERFACE)
-    target_compile_features(${PROJECT_NAME_LOWERCASE} INTERFACE cxx_std_23)
-else()
-    add_library(${PROJECT_NAME_LOWERCASE})
-    target_compile_features(${PROJECT_NAME_LOWERCASE} PUBLIC cxx_std_23)
-    verbose_message("Added all header and implementation files.\n")
-endif()
 
 # #############################################################################
 # Add version header: the location where the project's version header will be
@@ -150,32 +146,54 @@ configure_file(
 )
 string(TOLOWER ${PROJECT_NAME}/version.hpp VERSION_HEADER_LOCATION)
 
+if(${PROJECT_NAME_UPPERCASE}_BUILD_HEADERS_ONLY)
+    add_library(${PROJECT_NAME_LOWERCASE} INTERFACE)
+    target_compile_features(${PROJECT_NAME_LOWERCASE} INTERFACE cxx_std_23)
 
-target_sources(
-    ${PROJECT_NAME_LOWERCASE}
-    PRIVATE ${sources}
-    PUBLIC FILE_SET public_headers
-    TYPE HEADERS BASE_DIRS
-        ${CMAKE_CURRENT_SOURCE_DIR}/include
-        ${CMAKE_CURRENT_BINARY_DIR}
-    FILES
-        ${headers}
-        ${CMAKE_CURRENT_BINARY_DIR}/${VERSION_HEADER_LOCATION}
-)
+    target_sources(
+        ${PROJECT_NAME_LOWERCASE}
+        INTERFACE FILE_SET public_headers
+        TYPE HEADERS BASE_DIRS
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${CMAKE_CURRENT_BINARY_DIR}
+        FILES
+            ${headers}
+            ${CMAKE_CURRENT_BINARY_DIR}/${VERSION_HEADER_LOCATION}
+    )
 
-target_compile_options(
-    ${PROJECT_NAME_LOWERCASE}
-    PUBLIC "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->"
-)
+    target_compile_options(
+        ${PROJECT_NAME_LOWERCASE}
+        INTERFACE "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->"
+    )
+else()
+    add_library(${PROJECT_NAME_LOWERCASE})
+    target_compile_features(${PROJECT_NAME_LOWERCASE} PUBLIC cxx_std_23)
+    verbose_message("Added all header and implementation files.\n")
 
-# Link dependencies
-find_package(Threads)
-# Identify and link with the specific "packages" the project uses
-target_link_libraries(
-    ${PROJECT_NAME_LOWERCASE}
-    PRIVATE
-        Threads::Threads spdlog::spdlog
-)
+    target_sources(
+        ${PROJECT_NAME_LOWERCASE}
+        PRIVATE ${sources}
+        PUBLIC FILE_SET public_headers
+        TYPE HEADERS BASE_DIRS
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+            ${CMAKE_CURRENT_BINARY_DIR}
+        FILES
+            ${headers}
+            ${CMAKE_CURRENT_BINARY_DIR}/${VERSION_HEADER_LOCATION}
+    )
+
+    target_compile_options(
+        ${PROJECT_NAME_LOWERCASE}
+        PUBLIC "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->"
+    )
+
+    find_package(Threads REQUIRED)
+    target_link_libraries(
+        ${PROJECT_NAME_LOWERCASE}
+        PRIVATE
+            Threads::Threads spdlog::spdlog
+    )
+endif()
 
 if(CMAKE_SKIP_INSTALL_RULES)
     add_library(
@@ -218,13 +236,21 @@ packageProject(
 ##############################################################################
 if(PROJECT_IS_TOP_LEVEL)
     if(${PROJECT_NAME_UPPERCASE}_ENABLE_TESTING)
-        message(STATUS "Building unit tests for ${PROJECT_NAME}.\n")
-        enable_testing()
-        add_subdirectory(test)
+        if(${PROJECT_NAME_UPPERCASE}_BUILD_HEADERS_ONLY)
+            message(STATUS "Skipping unit tests for ${PROJECT_NAME} (header-only mode).\n")
+        else()
+            message(STATUS "Building unit tests for ${PROJECT_NAME}.\n")
+            enable_testing()
+            add_subdirectory(test)
+        endif()
     endif()
 
     if(${PROJECT_NAME_UPPERCASE}_ENABLE_STANDALONE)
-        add_subdirectory(standalone)
+        if(${PROJECT_NAME_UPPERCASE}_BUILD_HEADERS_ONLY)
+            message(STATUS "Skipping standalone app for ${PROJECT_NAME} (header-only mode).\n")
+        else()
+            add_subdirectory(standalone)
+        endif()
     endif()
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -98,9 +98,19 @@
             "configurePreset": "asan"
         },
         {
+            "name": "tsan",
+            "displayName": "Build (tsan)",
+            "configurePreset": "tsan"
+        },
+        {
             "name": "coverage",
             "displayName": "Build (coverage)",
             "configurePreset": "coverage"
+        },
+        {
+            "name": "warnings-as-errors",
+            "displayName": "Build (warnings-as-errors)",
+            "configurePreset": "warnings-as-errors"
         }
     ],
     "testPresets": [

--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,20 @@ coverage: ## check code coverage quickly GCC
 
 
 docs: ## generate Doxygen HTML documentation, including API docs
-	rm -rf docs/
+	@if ! command -v doxygen >/dev/null 2>&1; then \
+		echo "Error: Doxygen is not installed (missing 'doxygen' in PATH)."; \
+		echo "Install Doxygen and rerun 'make docs'."; \
+		exit 1; \
+	fi
 	rm -rf build/
-	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$(INSTALL_LOCATION) -DENABLE_DOXYGEN=1
-	cmake --build build --config Release
+	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$(INSTALL_LOCATION) \
+		-D$(PROJECT_NAME_UPPERCASE)_ENABLE_DOXYGEN=1
 	cmake --build build --target doxygen-docs
-	$(BROWSER) docs/html/index.html
+	@test -f build/docs/html/index.html || { \
+		echo "Error: documentation was not generated at build/docs/html/index.html."; \
+		exit 1; \
+	}
+	$(BROWSER) build/docs/html/index.html
 
 install: ## install the package to the `INSTALL_LOCATION`
 	rm -rf build/
@@ -87,4 +95,3 @@ check:
 		--force -q \
 		-I ./include ./src 2>&1 | tee cppcheck.txt
 	python ./ci/colorize_cppcheck_results.py
-

--- a/cmake/Doxygen.cmake
+++ b/cmake/Doxygen.cmake
@@ -1,0 +1,30 @@
+find_package(Doxygen OPTIONAL_COMPONENTS dot)
+
+if(NOT DOXYGEN_FOUND)
+    message(STATUS "Doxygen not found — documentation target will not be available.")
+    return()
+endif()
+
+set(DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/docs")
+set(DOXYGEN_GENERATE_HTML    YES)
+set(DOXYGEN_GENERATE_XML     NO)
+set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "${PROJECT_SOURCE_DIR}/README.md")
+set(DOXYGEN_PROJECT_NAME   "${PROJECT_NAME}")
+set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
+set(DOXYGEN_RECURSIVE      YES)
+set(DOXYGEN_QUIET          YES)
+set(DOXYGEN_WARN_IF_UNDOCUMENTED NO)
+
+if(DOXYGEN_DOT_FOUND)
+    set(DOXYGEN_HAVE_DOT YES)
+endif()
+
+doxygen_add_docs(
+    doxygen-docs
+    "${PROJECT_SOURCE_DIR}/include"
+    "${PROJECT_SOURCE_DIR}/src"
+    "${PROJECT_SOURCE_DIR}/README.md"
+    COMMENT "Generating API documentation with Doxygen"
+)
+
+message(STATUS "Doxygen ${DOXYGEN_VERSION} found — target 'doxygen-docs' available.")

--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -29,8 +29,14 @@ option(CXX_STANDARD_REQUIRED "Require C++ Standard" ON)
 set(CMAKE_DEBUG_POSTFIX d)
 # Always use '-fPIC'/'-fPIE' option.
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-#
-set(CMAKE_CONFIGURATION_TYPES "Debug" CACHE STRING "" FORCE)
+
+# For multi-config generators (Xcode, Visual Studio) provide all standard types.
+# For single-config generators CMAKE_BUILD_TYPE is set in CMakeLists.txt.
+get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_is_multi_config AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;MinSizeRel"
+        CACHE STRING "Available build configurations" FORCE)
+endif()
 
 
 if (${PROJECT_NAME_UPPERCASE}_MAKEFILE_VERBOSE_OUTPUT)

--- a/scripts/rename_project.sh
+++ b/scripts/rename_project.sh
@@ -1,75 +1,122 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Run this script from the repository root to rename the template.
+# Usage: ./scripts/rename_project.sh <NewProjectName>
+# Example: ./scripts/rename_project.sh MyAwesomeLib
+set -euo pipefail
 
-# Run this script at root directory to 
-# - replace "Greeter" with new project name in all CMakeLists.txt
-# - rename include/greeter to include/<project_name>
-
-# Check if new project name is provided
-if [ $# -eq 0 ]; then
-    echo "Usage: $0 <new_project_name>"
-    echo "Example: $0 MyProject"
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <NewProjectName>"
+    echo "Example: $0 MyAwesomeLib"
     exit 1
 fi
 
-# Validate project name: must start with a letter and contain only
-# alphanumeric characters, underscores, or dashes.
-if [[ ! "$1" =~ ^[a-zA-Z][a-zA-Z0-9_-]*$ ]]; then
-    echo "Error: Project name must start with a letter and contain only alphanumeric characters, underscores, or dashes."
+if [[ ! "$1" =~ ^[a-zA-Z][a-zA-Z0-9_]*$ ]]; then
+    echo "Error: project name must start with a letter and contain only"
+    echo "       alphanumeric characters or underscores."
     exit 1
 fi
 
-OLD_NAME="Greeter"
 NEW_NAME="$1"
-echo "Replacing '$OLD_NAME' with '$NEW_NAME' in CMakeLists.txt files ... "
-
-# Initialize counters
-FILES_PROCESSED=0
-REPLACEMENTS_TOTAL=0
-
-# Find and process all Makefiles
-while IFS= read -r -d '' file; do
-    # Count occurrences before replacement
-    OCCURRENCES=$(grep -o "$OLD_NAME" "$file" | wc -l)
-    
-    if [ "$OCCURRENCES" -gt 0 ]; then
-# Make the replacements
-        sed -i "s/$OLD_NAME/$NEW_NAME/g" "$file"
-        
-        # Update counters
-        REPLACEMENTS_TOTAL=$((REPLACEMENTS_TOTAL + OCCURRENCES))
-        FILES_PROCESSED=$((FILES_PROCESSED + 1))        
-    fi
-done < <(find . -type f -name CMakeLists.txt -print0)
-
-echo ""
-echo "Summary:"
-echo "Total Makefiles processed: $FILES_PROCESSED"
-echo "Total replacements made: $REPLACEMENTS_TOTAL"
-
-echo " Update include directory and includes"
-OLD_NAME_LOWER=$(echo "$OLD_NAME" | tr '[:upper:]' '[:lower:]')
 NEW_NAME_LOWER=$(echo "$NEW_NAME" | tr '[:upper:]' '[:lower:]')
-mv "include/${OLD_NAME_LOWER}" "include/${NEW_NAME_LOWER}"
-find . \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) -exec sed -i "s/#include <${OLD_NAME_LOWER}/#include <${NEW_NAME_LOWER}/g" {} \;
+NEW_NAME_UPPER=$(echo "$NEW_NAME_LOWER" | tr '[:lower:]' '[:upper:]')
 
-echo "-- Update project version testing --"
-OLD_NAME_UPPER=$(echo "$OLD_NAME" | tr '[:lower:]' '[:upper:]')
-NEW_NAME_UPPER=$(echo "$NEW_NAME" | tr '[:lower:]' '[:upper:]')
-find . -type f -exec sed -i "s/${OLD_NAME_UPPER}_/${NEW_NAME_UPPER}_/g" {} \;
+OLD_PROJECT="modern_cpp_project"
+OLD_PROJECT_UPPER="MODERN_CPP_PROJECT"
+OLD_CLASS="Greeter"
+OLD_NS="greeter"
+NEW_CLASS="$NEW_NAME"
+NEW_NS="$NEW_NAME_LOWER"
 
-# test new project is compilable and tested
-cmake -S . -B build
-cmake --build build
+echo "Renaming template:"
+echo "  project : $OLD_PROJECT  →  $NEW_NAME_LOWER"
+echo "  class   : $OLD_CLASS  →  $NEW_CLASS"
+echo "  macro   : $OLD_PROJECT_UPPER  →  $NEW_NAME_UPPER"
+echo ""
 
-# run tests
-ctest --test-dir build --output-on-failure
-# format code
-cmake --build build --target fix-format
-# run standalone
-APP_EXECUTABLE_NAME=$(grep -E 'set\(\s*APP_EXECUTABLE_NAME\s+' standalone/CMakeLists.txt | sed -E 's/.*set\(\s*APP_EXECUTABLE_NAME\s+([^)]+)\).*/\1/' | tr -d '[:space:]')
-if [ -z "$APP_EXECUTABLE_NAME" ]; then
+# ---------------------------------------------------------------------------
+# Portable sed -i: GNU sed uses -i, BSD (macOS) sed requires -i ''
+# ---------------------------------------------------------------------------
+sedi() {
+    if sed --version 2>/dev/null | grep -q GNU; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Files to process (exclude git, build artefacts, and CPM cache)
+# ---------------------------------------------------------------------------
+find_text_files() {
+    find . \
+        \( -name "*.cmake" -o -name "CMakeLists.txt" \
+        -o -name "*.cpp"   -o -name "*.hpp" -o -name "*.h" \
+        -o -name "*.md"    -o -name "*.json" \
+        -o -name "*.yml"   -o -name "*.yaml" \
+        -o -name "*.sh"    -o -name "Makefile" \) \
+        -not -path "./.git/*" \
+        -not -path "./build*" \
+        -not -path "./cpm_modules/*" \
+        -print0
+}
+
+# ---------------------------------------------------------------------------
+# 1. Replace CMake project name and macro prefix
+# ---------------------------------------------------------------------------
+echo "Step 1/3 — replacing project identifiers..."
+while IFS= read -r -d '' file; do
+    if grep -qF "$OLD_PROJECT_UPPER" "$file" 2>/dev/null; then
+        sedi "s/${OLD_PROJECT_UPPER}/${NEW_NAME_UPPER}/g" "$file"
+    fi
+    if grep -qF "$OLD_PROJECT" "$file" 2>/dev/null; then
+        sedi "s/${OLD_PROJECT}/${NEW_NAME_LOWER}/g" "$file"
+    fi
+done < <(find_text_files)
+
+# ---------------------------------------------------------------------------
+# 2. Replace class name and namespace in source/header files
+# ---------------------------------------------------------------------------
+echo "Step 2/3 — replacing class and namespace identifiers..."
+while IFS= read -r -d '' file; do
+    if grep -qF "$OLD_CLASS" "$file" 2>/dev/null; then
+        sedi "s/${OLD_CLASS}/${NEW_CLASS}/g" "$file"
+    fi
+    if grep -qF "namespace ${OLD_NS}" "$file" 2>/dev/null; then
+        sedi "s/namespace ${OLD_NS}/namespace ${NEW_NS}/g" "$file"
+    fi
+    if grep -qF "${OLD_NS}::" "$file" 2>/dev/null; then
+        sedi "s/${OLD_NS}::/${NEW_NS}::/g" "$file"
+    fi
+done < <(find . \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) \
+              -not -path "./.git/*" -not -path "./build*" -print0)
+
+# ---------------------------------------------------------------------------
+# 3. Rename include directory
+# ---------------------------------------------------------------------------
+echo "Step 3/3 — renaming include directory..."
+if [[ -d "include/${OLD_PROJECT}" ]]; then
+    mv "include/${OLD_PROJECT}" "include/${NEW_NAME_LOWER}"
+    echo "  include/${OLD_PROJECT} → include/${NEW_NAME_LOWER}"
+fi
+
+# ---------------------------------------------------------------------------
+# Verify: configure, build, and test
+# ---------------------------------------------------------------------------
+echo ""
+echo "Verifying rename — configuring..."
+cmake --preset dev
+
+echo "Building..."
+cmake --build --preset dev
+
+echo "Testing..."
+ctest --preset dev
+
+APP_EXECUTABLE_NAME=$(sed -nE 's/^[[:space:]]*set\(APP_EXECUTABLE_NAME[[:space:]]+"([^"]+)".*/\1/p' standalone/CMakeLists.txt | head -n 1)
+if [[ -z "${APP_EXECUTABLE_NAME}" ]]; then
     APP_EXECUTABLE_NAME="modern_cpp_app"
 fi
-"./build/standalone/${APP_EXECUTABLE_NAME}" --help
-# build docs
-cmake --build build --target GenerateDocs
+
+echo ""
+echo "Done! Project renamed to '${NEW_NAME_LOWER}'."
+echo "Standalone binary available at: build/dev/bin/${APP_EXECUTABLE_NAME}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,10 +57,16 @@ target_compile_features(${TEST_SUITE} PRIVATE cxx_std_23)
 # Enable compiler warnings
 # ######################################################################################################################
 if(NOT TEST_USE_INSTALLED_VERSION)
+    get_target_property(module_target_type ${MODULE_NAME} TYPE)
+    set(module_compile_scope PUBLIC)
+    if(module_target_type STREQUAL "INTERFACE_LIBRARY")
+        set(module_compile_scope INTERFACE)
+    endif()
+
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        target_compile_options(${MODULE_NAME} PUBLIC -Wall -Wpedantic -Wextra -Werror)
+        target_compile_options(${MODULE_NAME} ${module_compile_scope} -Wall -Wpedantic -Wextra -Werror)
     elseif(MSVC)
-        target_compile_options(${MODULE_NAME} PUBLIC /W4 /WX)
+        target_compile_options(${MODULE_NAME} ${module_compile_scope} /W4 /WX)
     endif()
 endif()
 # ######################################################################################################################
@@ -75,10 +81,16 @@ add_test(NAME ${TEST_SUITE} COMMAND ${TEST_SUITE})
 # ######################################################################################################################
 # Setup code coverage if enabled
 # ######################################################################################################################
-if (${MODULE_NAME}_ENABLE_CODE_COVERAGE OR ENABLE_CODE_COVERAGE)
+if((${MODULE_NAME}_ENABLE_CODE_COVERAGE OR ENABLE_CODE_COVERAGE) AND TARGET ${MODULE_NAME})
+    get_target_property(module_target_type ${MODULE_NAME} TYPE)
+    set(module_compile_scope PUBLIC)
+    if(module_target_type STREQUAL "INTERFACE_LIBRARY")
+        set(module_compile_scope INTERFACE)
+    endif()
+
     # ---- code coverage ----
-    target_compile_options(${MODULE_NAME} PUBLIC -O0 -g -fprofile-arcs -ftest-coverage)
-    target_link_options(${MODULE_NAME} PUBLIC -fprofile-arcs -ftest-coverage)
+    target_compile_options(${MODULE_NAME} ${module_compile_scope} -O0 -g -fprofile-arcs -ftest-coverage)
+    target_link_options(${MODULE_NAME} ${module_compile_scope} -fprofile-arcs -ftest-coverage)
 endif()
 
 


### PR DESCRIPTION
Fixes #XXXX

## Proposed changes

- Fixed header-only mode integration at the top-level build:
  - Skip `test/` and `standalone/` subprojects when `MODERN_CPP_PROJECT_BUILD_HEADERS_ONLY=ON` to avoid invalid target operations on interface libraries.
  - Added clear CMake status messages for these skips.
- Made `test/CMakeLists.txt` resilient to interface-library targets:
  - Warnings/coverage flags now use `INTERFACE` scope when the module target is `INTERFACE_LIBRARY`.
- Restored preset parity with documentation:
  - Added missing build presets for `tsan` and `warnings-as-errors`.
- Improved multi-config generator behavior:
  - Set full standard configuration types for Xcode/Visual Studio (`Debug;Release;RelWithDebInfo;MinSizeRel`) instead of effectively forcing Debug-only behavior.
- Added Doxygen module and wiring:
  - Introduced `cmake/Doxygen.cmake`.
  - Integrated Doxygen enabling from top-level CMake options.
  - Updated docs workflow to a valid path and modern GitHub Actions versions.
- Hardened helper tooling:
  - `scripts/rename_project.sh` is now portable across GNU/BSD `sed`.
  - Script now rejects hyphenated project names to avoid generating invalid C++ identifiers.
  - Fixed final standalone binary path message in rename script.
  - `make docs` now fails early with a clear error if Doxygen is missing and validates generated output location.

## Motivation behind changes

This PR addresses multiple regressions and inconsistencies discovered during end-to-end validation of the template:

1. Header-only mode was not safely compatible with the default top-level build flow.
2. Build presets and generator behavior did not fully match documented usage.
3. Documentation generation paths/targets were inconsistent across local and CI workflows.
4. Rename tooling allowed inputs that could produce uncompilable C++ code.

These fixes improve reliability for first-time users and reduce template breakage in common setup paths.

## Test plan

Executed locally:

- `cmake --preset dev`
- `cmake --build --preset dev`
- `ctest --preset dev`
- `cmake -S . -B build/headers-only-full -DMODERN_CPP_PROJECT_BUILD_HEADERS_ONLY=ON`
- `cmake --build build/headers-only-full`
- `cmake --preset tsan`
- `cmake --build --preset tsan`
- `cmake --preset warnings-as-errors`
- `cmake --build --preset warnings-as-errors`
- `cmake -S . -B build/xcode-check-2 -G Xcode -DMODERN_CPP_PROJECT_ENABLE_TESTING=OFF -DMODERN_CPP_PROJECT_ENABLE_STANDALONE=OFF`
- `cmake --build build/xcode-check-2 --config Release`
- Rename script smoke tests in isolated temp copies:
  - `./scripts/rename_project.sh AwesomeLib` (configure/build/test pass)
  - `./scripts/rename_project.sh My-Project` (now correctly rejected)

Docs-specific validation:

- `make docs` now fails fast with a clear message when `doxygen` is not installed.
- Full HTML generation was not executed on this machine due missing local Doxygen binary.

## Pull Request Readiness Checklist

- [x] I agree to contribute to the project under the project license.
- [x] To the best of my knowledge, the proposed patch is not based on incompatible licensed code.
- [x] The PR is proposed to the proper branch.
- [ ] There is reference to original bug report and related work.
- [x] Relevant accuracy/build tests were executed.
- [x] The feature/tooling behavior is documented in code and workflow updates.
